### PR TITLE
adds getBatchId() to AuthResponse

### DIFF
--- a/src/Omnipay/Realex/Message/AuthResponse.php
+++ b/src/Omnipay/Realex/Message/AuthResponse.php
@@ -37,6 +37,11 @@ class AuthResponse extends RemoteAbstractResponse implements RedirectResponseInt
         return ($this->xml->authcode) ? (string)$this->xml->authcode : null;
     }
 
+    public function getBatchId()
+    {
+        return ($this->xml->batchid) ? (string)$this->xml->batchid : null;
+    }
+
     public function isRedirect()
     {
         return false;


### PR DESCRIPTION
Allows access to the batchId message returned in the realex xml response.

closes #11