### PR TITLE
Allow a user to change the API endpoint and get the raw XML response 

### DIFF
--- a/src/Omnipay/Realex/Message/AuthRequest.php
+++ b/src/Omnipay/Realex/Message/AuthRequest.php
@@ -51,6 +51,9 @@ class AuthRequest extends RemoteAbstractRequest
     {
         $this->validate('amount', 'currency', 'transactionId');
 
+        // Set the endpoint to be used during the connection
+        $this->setEndpoint($this->getEndpoint());
+
         // Create the hash
         $timestamp = strftime("%Y%m%d%H%M%S");
         $merchantId = $this->getMerchantId();
@@ -162,5 +165,10 @@ class AuthRequest extends RemoteAbstractRequest
     public function getEndpoint()
     {
         return $this->endpoint;
+    }
+
+    public function setEndpoint($value)
+    {
+        $this->endpoint = $value;
     }
 }

--- a/src/Omnipay/Realex/Message/AuthResponse.php
+++ b/src/Omnipay/Realex/Message/AuthResponse.php
@@ -64,4 +64,12 @@ class AuthResponse extends RemoteAbstractResponse implements RedirectResponseInt
     {
         return '';
     }
+
+    /**
+     * Returns the full xml response
+     */
+    public function getXML()
+    {
+        return $this->xml->asXML();
+    }
 }

--- a/src/Omnipay/Realex/Message/EnrolmentRequest.php
+++ b/src/Omnipay/Realex/Message/EnrolmentRequest.php
@@ -124,4 +124,9 @@ class EnrolmentRequest extends RemoteAbstractRequest
     {
         return $this->endpoint;
     }
+
+    public function setEndpoint($endpoint)
+    {
+        $this->endpoint = $endpoint;
+    }
 }

--- a/src/Omnipay/Realex/Message/EnrolmentRequest.php
+++ b/src/Omnipay/Realex/Message/EnrolmentRequest.php
@@ -114,6 +114,10 @@ class EnrolmentRequest extends RemoteAbstractRequest
             $request = new AuthRequest($this->httpClient, $this->httpRequest);
             $request->initialize($this->getParameters());
 
+            if (method_exists($request, 'setEndpoint')) {
+                $request->setEndpoint($this->getEndpoint());
+            }
+
             $response = $request->send();
         }
 

--- a/src/Omnipay/Realex/Message/EnrolmentResponse.php
+++ b/src/Omnipay/Realex/Message/EnrolmentResponse.php
@@ -96,4 +96,12 @@ class EnrolmentResponse extends RemoteAbstractResponse implements RedirectRespon
             'MD'      => $this->getMerchantData()
         );
     }
+
+    /**
+     * Returns the full xml response
+     */
+    public function getXML()
+    {
+        return $this->xml->asXML();
+    }
 }

--- a/src/Omnipay/Realex/Message/VerifySigRequest.php
+++ b/src/Omnipay/Realex/Message/VerifySigRequest.php
@@ -161,6 +161,7 @@ class VerifySigRequest extends RemoteAbstractRequest
              * @var AuthResponse $response
              */
             $request = new AuthRequest($this->httpClient, $this->httpRequest);
+            $request->setEndpoint($this->getEndpoint());
             $request->initialize($parameters);
 
             $response = $request->send();

--- a/src/Omnipay/Realex/Message/VerifySigRequest.php
+++ b/src/Omnipay/Realex/Message/VerifySigRequest.php
@@ -129,6 +129,11 @@ class VerifySigRequest extends RemoteAbstractRequest
         return $this->endpoint;
     }
 
+    public function setEndpoint($endpoint)
+    {
+        $this->endpoint = $endpoint;
+    }
+
     /**
      * @param mixed $parameters
      *

--- a/src/Omnipay/Realex/Message/VerifySigResponse.php
+++ b/src/Omnipay/Realex/Message/VerifySigResponse.php
@@ -89,4 +89,12 @@ class VerifySigResponse extends RemoteAbstractResponse implements RedirectRespon
     {
         return '';
     }
+
+    /**
+     * Returns the full xml response
+     */
+    public function getXML()
+    {
+        return $this->xml->asXML();
+    }
 }

--- a/src/Omnipay/Realex/RemoteGateway.php
+++ b/src/Omnipay/Realex/RemoteGateway.php
@@ -87,6 +87,16 @@ class RemoteGateway extends AbstractGateway
     {
         return $this->setParameter('3dSecure', $value);
     }
+    protected function createRequest($class, array $parameters)
+    {
+        $obj = new $class($this->httpClient, $this->httpRequest);
+        // Set the endpoint on the subject class if available
+        if (method_exists($obj, 'setEndpoint')) {
+            $obj->setEndpoint($this->getEndpoint());
+        }
+
+        return $obj->initialize(array_replace($this->getParameters(), $parameters));
+    }
 
     public function purchase(array $parameters = array())
     {

--- a/src/Omnipay/Realex/RemoteGateway.php
+++ b/src/Omnipay/Realex/RemoteGateway.php
@@ -150,4 +150,12 @@ class RemoteGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\Realex\Message\UpdateCustomerRequest', $parameters);
     }
+
+    /**
+     * Allow the user to set the endpoint
+     */
+    public function setEndpoint($value)
+    {
+      return $this->setParameter('endpoint', $value);
+    }
 }

--- a/src/Omnipay/Realex/RemoteGateway.php
+++ b/src/Omnipay/Realex/RemoteGateway.php
@@ -168,4 +168,9 @@ class RemoteGateway extends AbstractGateway
     {
         return $this->setParameter('endpoint', $value);
     }
+
+    public function getEndpoint()
+    {
+        return $this->getParameter('endpoint');
+    }
 }

--- a/src/Omnipay/Realex/RemoteGateway.php
+++ b/src/Omnipay/Realex/RemoteGateway.php
@@ -171,6 +171,10 @@ class RemoteGateway extends AbstractGateway
 
     public function getEndpoint()
     {
-        return $this->getParameter('endpoint');
+        if (null !== $this->getParameter('endpoint')) {
+            return $this->getParameter('endpoint');
+        } else {
+            return 'https://epage.payandshop.com/epage-remote.cgi';
+        }
     }
 }

--- a/src/Omnipay/Realex/RemoteGateway.php
+++ b/src/Omnipay/Realex/RemoteGateway.php
@@ -156,6 +156,6 @@ class RemoteGateway extends AbstractGateway
      */
     public function setEndpoint($value)
     {
-      return $this->setParameter('endpoint', $value);
+        return $this->setParameter('endpoint', $value);
     }
 }


### PR DESCRIPTION
## Changes

function : getXML
Returns the xml response received from the Realex API. This returns far more informaiton to the user such as authcodes and batchIds.

functions : setEndPoint
Allow the user to set the url that the request should be made too. This is set before purchase is called similar to setMerchantId etc. If not set it will use the default endpoint. 
